### PR TITLE
Fix: get the background image of `IntroSection` smaller in height-wise

### DIFF
--- a/frontend/components/hp/IntroSection.tsx
+++ b/frontend/components/hp/IntroSection.tsx
@@ -56,9 +56,9 @@ const IntroSection = (): JSX.Element => {
       <Image
         src={Block}
         alt="Block"
-        className="absolute md:-right-20 -right-10 lg:bottom-28 -bottom-12 w-auto xl:h-[350px] lg:h-[250px] sm:h-[200px] h-[130px]"
+        className="absolute md:-right-20 -right-10 lg:-bottom-20 -bottom-12 w-auto xl:h-[350px] lg:h-[250px] sm:h-[200px] h-[130px]"
       />
-      <div className="absolute md:-left-20 -left-10 lg:bottom-28 -bottom-12">
+      <div className="absolute md:-left-20 -left-10 lg:-bottom-32 -bottom-12">
         <motion.p
             variants={textVariant()}
             initial="hidden"

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -37,7 +37,7 @@ const SectionWrapper: React.FC<SectionWrapperPropsInterface> = ({
 }): JSX.Element => {
   return (
     <motion.div
-      className={`w-full grid grid-cols-12 xl:py-20 sm:py-14 py-14 overflow-hidden relative ${bgColor === "" ? "xl:min-h-[1024px] lg:min-h-[760px] sm:min-h-[500px]" : ""} ${bgColor || "bg-custom-background2 bg-contain"}`}
+      className={`w-full grid grid-cols-12 xl:py-20 sm:py-14 py-14 overflow-hidden relative h-[850px] ${bgColor || "bg-custom-background2 bg-contain"}`}
     >
       {/* {glowStyles && <Glow styles={glowStyles} />} */}
       <div className="col-start-2 col-end-12 font-semibold relative">


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Close #539 

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [ ] My code follows the style guidelines(linter) of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have confirmed the code I wrote has been imported with a relative path
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots

 - Device: [e.g. iPhone6]
 - OS: [e.g. iOS8.1]
 - Browser [e.g. stock browser, safari]
 - Version [e.g. 22]

| Mobile |  PC  | 
| ---- | ---- | 
|  ![]()  | ![]() | 
