### PR TITLE
Fix: a bug where the file selection modal would be displayed twice when using getRootProps

### DIFF
--- a/frontend/components/projectDetails/Dropbox.tsx
+++ b/frontend/components/projectDetails/Dropbox.tsx
@@ -28,7 +28,10 @@ const Dropbox = ({
     setFiles(prevFiles => [...prevFiles, ...acceptedFiles]);
   }, []);
 
-  const { getRootProps, getInputProps } = useDropzone({ onDrop });
+  const { getRootProps, getInputProps } = useDropzone({ 
+    onDrop, 
+    noClick: true // This fixes a bug where the file selection modal would be displayed twice when using getRootProps.
+  });
 
   return (
     <>


### PR DESCRIPTION
# Description

- Add `noClick: true` to `useDropzone`

Close #588

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [ ] My code follows the style guidelines(linter) of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have confirmed the code I wrote has been imported with a relative path
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots

 - Device: [e.g. iPhone6]
 - OS: [e.g. iOS8.1]
 - Browser [e.g. stock browser, safari]
 - Version [e.g. 22]

| Mobile |  PC  | 
| ---- | ---- | 
|  ![]()  | ![]() | 
